### PR TITLE
use `update:model-value` instead of `update:modelValue` (in-DOM)

### DIFF
--- a/vuetifyx/filter.go
+++ b/vuetifyx/filter.go
@@ -68,7 +68,7 @@ func (b *VXFilterBuilder) MarshalHTML(ctx context.Context) (r []byte, err error)
 			Go()
 	}
 
-	b = b.InternalValue(visibleFilterData).Attr("@update:modelValue", b.updateModelValue)
+	b = b.InternalValue(visibleFilterData).Attr("@update:model-value", b.updateModelValue)
 
 	return b.tag.MarshalHTML(ctx)
 }


### PR DESCRIPTION
如果通过 Drawer 点进 Customer，筛选标签修改后是可以响应筛选的，但是如果直接访问链接，修改筛选标签的话，列表目前不会响应筛选，从 url query 的变动即可看出。

docs 对应 demo: [Listing Customers - Admin](http://localhost:8800/samples/presets-listing-customization-filters/customers) **branch vue3 才有此问题**。

经查是由于 in-DOM 下大小写不敏感的问题导致的，改为 kebab-case 即可。